### PR TITLE
adding sec group id as module output

### DIFF
--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -2,3 +2,8 @@ output "aws_lb_dns" {
   description = "The load balancer url. This will start returning HTTP 200 approx. 5 minutes after the terraform is deployed."
   value       = module.ecs.aws_lb_dns
 }
+
+output "security_group_id" {
+  description = "ECS security group ID used for Secoda"
+  value       = aws_security_group.ecs_sg.id
+}


### PR DESCRIPTION
Adding the id of the ECS security group as output of the module. 

The reason for adding this is that we want to integrate this tf module to our own tf repo. When allowing traffic to our redshift cluster we want to use the this output instead of hardcoding the security group in our tf repo. 